### PR TITLE
Add additional required packages to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,12 +3,13 @@ channels:
 dependencies:
 - python >= 3.9
 - click
+- fiona
 - geopandas-base
 - numpy
 - pandas
 - pip
+- requests
 - shapely
 - tqdm
 - utm
-- pip:
-  - unzip-http
+- unzip-http


### PR DESCRIPTION
Following the readme instructions I noticed fiona is installed during the pip install step. 

Also `ModuleNotFoundError: No module named 'requests'` shows up and needs to be added :
```
Traceback (most recent call last):
  File "/Users/scott/miniforge3/envs/opera/bin/opera-db", line 5, in <module>
    from burst_db.cli import cli_app
  File "/Users/scott/miniforge3/envs/opera/lib/python3.12/site-packages/burst_db/cli.py", line 3, in <module>
    from .build_frame_db import create
  File "/Users/scott/miniforge3/envs/opera/lib/python3.12/site-packages/burst_db/build_frame_db.py", line 20, in <module>
    from ._land_usgs import GREENLAND_URL, USGS_LAND_URL, get_greenland_shape, get_land_df
  File "/Users/scott/miniforge3/envs/opera/lib/python3.12/site-packages/burst_db/_land_usgs.py", line 9, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

So this change just gets everything from conda-forge.