### PR TITLE
Add missing dependencies: duckdb, opera-utils

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,4 @@ repos:
         additional_dependencies:
         - types-setuptools
         - types-requests
+        - types-python-dateutil

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 dependencies:
 - python >= 3.9
 - click
+- duckdb
 - fiona
 - geopandas-base
 - numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 click
+duckdb
 geopandas
 numpy
+opera-utils
 pandas
 shapely
 tqdm

--- a/scripts/historical_bursts/parse_bursts.py
+++ b/scripts/historical_bursts/parse_bursts.py
@@ -670,9 +670,9 @@ def bursts_from_safe_dir(
 
     Parameters
     ----------
-    path : str
+    path : str | Path
         Path to SAFE directory.
-    orbit_path : str
+    orbit_path : str | Path
         Path the orbit file.
 
     Returns
@@ -697,7 +697,7 @@ def bursts_from_safe_dir(
         raise ValueError(f"No annotation files found in {path}")
 
     for f_annotation in annotation_files:
-        bursts.extend(_bursts_from_xml(str(f_annotation), orbit_path))
+        bursts.extend(_bursts_from_xml(str(f_annotation), str(orbit_path)))
     if not bursts:
         logger.error(f"No bursts found in {path}")
 
@@ -774,7 +774,7 @@ def pull_safes_for_date(
         matching_granules = _find_matching(search_term, full_safe_list)
         zip_filenames = [f"{f}.SAFE.zip" for f in matching_granules]
         return _get_objects(
-            zip_filenames, bucket, in_folder, out_dir, max_workers=max_workers
+            zip_filenames, bucket, in_folder, Path(out_dir), max_workers=max_workers
         )
 
 

--- a/src/burst_db/_esa_burst_db.py
+++ b/src/burst_db/_esa_burst_db.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import tempfile
 import zipfile
+from pathlib import Path
 
 ESA_DB_URL = "https://sar-mpc.eu/files/S1_burstid_20220530.zip"
 
@@ -13,8 +14,8 @@ def get_esa_burst_db(output_path="burst_map_IW_000001_375887.sqlite3"):
     """Download the ESA burst database."""
     print(f"Downloading ESA burst database from {ESA_DB_URL} to {output_path}.")
     db_filename = "S1_burstid_20220530/IW/sqlite/burst_map_IW_000001_375887.sqlite3"
-    cur_dir = os.getcwd()
-    output_path = os.path.abspath(output_path)
+    cur_dir = Path.cwd()
+    output_path = Path(output_path).absolute()
     with tempfile.TemporaryDirectory() as tmpdir:
         try:
             os.chdir(tmpdir)

--- a/src/burst_db/_land_usgs.py
+++ b/src/burst_db/_land_usgs.py
@@ -17,9 +17,9 @@ GREENLAND_URL = "https://stacks.stanford.edu/file/druid:sd368wz2435/data.zip"
 
 
 def get_usgs_land(outpath=None):
-    """Get the USGS land data from the following url:
+    """Download the USGS land data.
 
-    https://www.ngdc.noaa.gov/mgg/shorelines/data/gshhg/latest/gshhg-shp-2.3.7.zip
+    From URL: https://www.ngdc.noaa.gov/mgg/shorelines/data/gshhg/latest/gshhg-shp-2.3.7.zip
     """
     outpath = Path(outpath) if outpath else Path.cwd()
     rzf = unzip_http.RemoteZipFile(USGS_LAND_URL)
@@ -82,9 +82,9 @@ def get_land_df(
 
 
 def get_greenland_shape(outpath=None, buffer_deg=0.2) -> MultiPolygon:
-    """Get the Greenland data from the following URL:
+    """Download the Greenland data.
 
-    https://stacks.stanford.edu/file/druid:sd368wz2435/data.zip
+    From URL: https://stacks.stanford.edu/file/druid:sd368wz2435/data.zip
     """
     outpath = Path(outpath) if outpath else Path.cwd()
     outname = outpath / f"greenland_{buffer_deg}deg_buffered.geojson"

--- a/src/burst_db/create_2d_geojsons.py
+++ b/src/burst_db/create_2d_geojsons.py
@@ -7,7 +7,7 @@ from burst_db import VERSION_CLEAN, __version__
 def create_2d_geojsons(
     in_file: str = f"opera-s1-disp-{VERSION_CLEAN}.gpkg",
 ) -> list[Path]:
-    """Creates 2D GeoJSON files from a 3D GeoPackage database.
+    """Create 2D GeoJSON files from a 3D GeoPackage database.
 
     This function takes a 3D GeoPackage database containing burst geometry
     and metadata, extracts 2D representations of the geometry.

--- a/src/burst_db/frames.py
+++ b/src/burst_db/frames.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import math
-from collections import Counter, namedtuple
+from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
 from functools import lru_cache
 from itertools import groupby, repeat
+from typing import NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -15,7 +16,13 @@ MIN_FRAME = 5
 MAX_FRAME = 12
 TARGET_FRAME = 10
 
-FrameSlice = namedtuple("FrameSlice", ["start_idx", "end_idx", "is_land"])
+
+class FrameSlice(NamedTuple):
+    """A slice of frames with start, end indices and a land indicator."""
+
+    start_idx: int
+    end_idx: int
+    is_land: bool
 
 
 def create_frame_to_burst_mapping(
@@ -137,7 +144,8 @@ def solve(n, target=TARGET_FRAME, max_frame=MAX_FRAME, min_frame=MIN_FRAME):
     Notes
     -----
     This is posed as the same problem as the text justification problem.
-    "words" == bursts. "lines" == Frames. Where to "break the lines" == "group the frames"
+    "words" == bursts. "lines" == Frames.
+    Where to "break the lines" == "group the frames"
 
     The differences between here and reference [1]_ are
 
@@ -151,7 +159,8 @@ def solve(n, target=TARGET_FRAME, max_frame=MAX_FRAME, min_frame=MIN_FRAME):
     Reference
     ---------
     ..[1] https://ocw.mit.edu/courses/6-006-introduction-to-algorithms-fall-2011/resources/mit6_006f11_lec20/
-    """  # noqa
+
+    """
     # DP[i][0] is the minimum badness of the frames starting at i
     # and DP[i][1] is the index of the next frame (to backtrack and get the slices)
     DP = [None] * (n + 1)

--- a/src/burst_db/query_historical_bursts.py
+++ b/src/burst_db/query_historical_bursts.py
@@ -217,6 +217,10 @@ def get_gdf(
     to_geodataframe: bool = False,
     debug: bool = False,
 ):
+    """Get a GeoDataFrame or DataFrame of bursts that intersect a given WKT geometry.
+
+    Optionally filtered by datetime range.
+    """
     import duckdb
     import shapely.wkt
 

--- a/src/burst_db/utils.py
+++ b/src/burst_db/utils.py
@@ -10,11 +10,12 @@ from shapely import box
 def read_zipped_json(filename: str | Path) -> dict:
     """Read a ".json.zip" file into a dict."""
     with zipfile.ZipFile(filename) as zf:
-        bytes = zf.read(str(Path(filename).name).replace(".zip", ""))
-        return json.loads(bytes.decode())
+        bytes_ = zf.read(str(Path(filename).name).replace(".zip", ""))
+        return json.loads(bytes_.decode())
 
 
 def write_zipped_json(json_path: str, dict_out: dict, level: int = 6):
+    """Write a JSON dictionary to a sibling compressed ".json.zip" file."""
     json_zip_path = str(json_path) + ".zip"
     with zipfile.ZipFile(
         json_zip_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=level


### PR DESCRIPTION
The build directions on the readme failed until we added these dependencies. 

Note:
- I'm assuming we want to fetch duckdb from conda and opera-utils as a pip dependency.
- Includes a commit to fix the mypy/ruff warnings that are causing pre-commit to fail in CI. I'm happy to move this to a separate PR if it's too much.
- I've rerun `opera-db create` and it appears to finish successfully after the above changes.