### PR TITLE
Add `urls-for-frame` to query ASF for the consistent CSLC bursts

### DIFF
--- a/src/burst_db/build_frame_db.py
+++ b/src/burst_db/build_frame_db.py
@@ -30,12 +30,8 @@ NORTH_EPSG = 3413
 # Threshold to use EPSG:3031, Antarctic Polar Stereographic (https://epsg.io/3031)
 SOUTH_THRESHOLD = -60
 SOUTH_EPSG = 3031
-logger = logging.getLogger(__name__)
-logging.basicConfig(
-    handlers=[logging.StreamHandler()],
-    format="[%(levelname)s|%(module)s|L%(lineno)d] %(asctime)s: %(message)s",
-    level=logging.INFO,
-)
+
+logger = logging.getLogger("burst_db")
 
 
 def make_jpl_burst_id(df: pd.DataFrame):

--- a/src/burst_db/cli.py
+++ b/src/burst_db/cli.py
@@ -1,21 +1,38 @@
+import logging
+
 import click
 
 from .build_frame_db import create
 from .create_cslc_burst_catalog import make_burst_catalog
+from .query_consistent_bursts import urls_for_frame
 from .query_frame_db import intersect, lookup
 from .query_historical_bursts import fetch_bursts, fetch_granules
 from .reference_dates import make_reference_dates
+
+logger = logging.getLogger("burst_db")
 
 
 @click.group()
 def cli_app():
     """Create/interact with OPERA's burst/frame databases."""
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    # if verbose:
+    #     handler.setLevel(logging.DEBUG)
+    # else:
+    #     handler.setLevel(logging.INFO)
+    formatter = logging.Formatter(
+        "[%(levelname)s|%(module)s|L%(lineno)d] %(asctime)s: %(message)s"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
 
 cli_app.add_command(create)
 cli_app.add_command(intersect)
 cli_app.add_command(lookup)
 cli_app.add_command(make_burst_catalog)
+cli_app.add_command(urls_for_frame)
 cli_app.add_command(make_reference_dates)
 
 

--- a/src/burst_db/cli.py
+++ b/src/burst_db/cli.py
@@ -16,16 +16,12 @@ logger = logging.getLogger("burst_db")
 def cli_app():
     """Create/interact with OPERA's burst/frame databases."""
     handler = logging.StreamHandler()
-    handler.setLevel(logging.INFO)
-    # if verbose:
-    #     handler.setLevel(logging.DEBUG)
-    # else:
-    #     handler.setLevel(logging.INFO)
     formatter = logging.Formatter(
         "[%(levelname)s|%(module)s|L%(lineno)d] %(asctime)s: %(message)s"
     )
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
 
 
 cli_app.add_command(create)


### PR DESCRIPTION
Example usage:

```
opera-db urls-for-frame 31226     # Default options- echos HTTPS urls to stdout
opera-db urls-for-frame 31226 --output-type s3     # Print the S3 direct access urls instead
```
The `--json-file` option defaults to the [last result from this PR](https://github.com/opera-adt/burst_db/pull/37). The tool loads the JSON file, queries ASF, then filters to only keep the sensing times listed in the JSON.