### PR TITLE
Add script to convert monthly geojson of snow cover into JSON db file, exclude from consistent burst DB

### DIFF
--- a/src/burst_db/create_blackout_dates_s1.py
+++ b/src/burst_db/create_blackout_dates_s1.py
@@ -1,0 +1,95 @@
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import geopandas as gpd
+
+logger = logging.getLogger(__name__)
+
+
+def gdf_to_blackout_json(input_file: Path | str) -> dict:
+    """Create a JSON of blackout periods for DISP-S1.
+
+    Convert a GeoJSON file with year, month, frame_id, and to_process information
+    into a JSON with blackout dates.
+
+    Parameters
+    ----------
+    input_file : str
+        The path to the input GeoJSON file.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the blackout dates for each frame_id and metadata.
+
+    Notes
+    -----
+    This function reads a GeoJSON file, processes it to create blackout dates
+    for periods where to_process is 0, saves the result to a JSON file,
+    and returns the resulting dictionary.
+
+    """
+    # Read the GeoJSON file
+    gdf = gpd.read_file(input_file)
+
+    blackout_dates: dict[str, list[list[str]]] = {}
+
+    for frame_id, group in gdf.groupby("frame_id"):
+        frame_dates = []
+        blackout_start = None
+
+        # Sort the group by year and month
+        group_sorted = group.sort_values(["year", "month"])
+
+        for _, row in group_sorted.iterrows():
+            year = int(row["year"])
+            month = int(row["month"])
+            to_process = int(row["to_process"])
+
+            current_date = datetime(year, month, 1)
+
+            if to_process == 0:
+                if blackout_start is None:
+                    blackout_start = current_date
+            else:
+                if blackout_start is not None:
+                    # End the blackout period at the very end of the previous month
+                    blackout_end = current_date - timedelta(days=1)
+                    blackout_end = blackout_end.replace(hour=23, minute=59, second=59)
+                    frame_dates.append(
+                        [blackout_start.isoformat(), blackout_end.isoformat()]
+                    )
+                    blackout_start = None
+
+        # Check if there's an ongoing blackout period at the end of the data
+        if blackout_start is not None:
+            frame_dates.append(
+                [
+                    blackout_start.isoformat(),
+                    str(group_sorted.iloc[-1]["year"]) + "-12-31",
+                ]
+            )
+
+        blackout_dates[str(frame_id)] = frame_dates or []
+
+    generation_time = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_filename = f"disp-s1-blackout-dates-{generation_time}.json"
+
+    result = {
+        "metadata": {
+            "generation_time": datetime.now().isoformat(),
+            "input_file": Path(input_file).name,
+            "output_file": output_filename,
+        },
+        "blackout_dates": blackout_dates,
+    }
+
+    # Save the result to a JSON file
+    with open(output_filename, "w") as f:
+        json.dump(result, f, indent=2)
+
+    logger.info(f"JSON file created: {output_filename}")
+
+    return result

--- a/src/burst_db/create_blackout_dates_s1.py
+++ b/src/burst_db/create_blackout_dates_s1.py
@@ -74,7 +74,7 @@ def gdf_to_blackout_json(input_file: Path | str) -> dict:
 
         blackout_dates[str(frame_id)] = frame_dates or []
 
-    generation_time = datetime.now().strftime("%Y%m%d_%H%M%S")
+    generation_time = datetime.now().strftime("%Y-%m-%d")
     output_filename = f"disp-s1-blackout-dates-{generation_time}.json"
 
     result = {


### PR DESCRIPTION
Script for changing @gracebato 's geojson into the format suggested by @philipjyoon 

```python
gpd.read_file("blockout_snow_disp_s1.geojson")
Out[2]:
        frame_id  year  month  to_process                                           geometry
0             95  2016      7           1  POLYGON ((174.6763 52.5153, 172.89022 52.62514...
1             96  2016      7           1  POLYGON ((174.30093 51.19519, 172.56574 51.304...
2            831  2016      7           1  POLYGON ((-77.63462 33.64007, -77.94576 34.985...
3            832  2016      7           1  POLYGON ((-77.94234 34.97052, -78.25801 36.313...
...

```

```python
In [53]: json_result2 = burst_db.create_blackout_dates_s1.gdf_to_blackout_json("/Users/staniewi/Downloads/blockout_snow_disp_s1.geojson")
JSON file created: disp-s1-blackout-dates-2024-10-11.json
```


appears to be right:
```python


In [54]: json_result2['blackout_dates']['835']
Out[54]:
[['2021-02-01T00:00:00', '2021-02-28T23:59:59'],
 ['2022-01-01T00:00:00', '2022-01-31T23:59:59']]

In [52]: gdf[(gdf.frame_id == 835) & (gdf.to_process == 0)]
Out[52]:
        frame_id  year  month  to_process                                           geometry
92400        835  2021      2           0  POLYGON ((-78.89565 38.95445, -79.2289 40.2946...
111221       835  2022      1           0  POLYGON ((-78.89565 38.95445, -79.2289 40.2946...

```

frames with no entries as `to_process == 0` have an empty list:
```python

In [55]: json_result2['blackout_dates']['831']
Out[55]: []

```
