### PR TITLE
Fix sql interpolation error in `build_frame_db`

### DIFF
--- a/src/burst_db/build_frame_db.py
+++ b/src/burst_db/build_frame_db.py
@@ -385,7 +385,7 @@ def add_gpkg_spatial_ref_sys(outfile):
         )
         # Ignore when exists.
         with contextlib.suppress(sqlite3.OperationalError, sqlite3.IntegrityError):
-            con.execute(sql, UTM_32760_DEF)
+            con.execute(sql, (UTM_32760_DEF,))
 
         # More the entries from gpkg_spatial_ref_sys to spatial_ref_sys
         # so we can use the `ST_Transform` function

--- a/src/burst_db/create_cslc_burst_catalog.py
+++ b/src/burst_db/create_cslc_burst_catalog.py
@@ -326,7 +326,6 @@ def make_burst_catalog(
 
     INPUT_CSV: Path to the input CSV file containing CMR-queried burst data.
     OPERA_DB: Path to the OPERA DISP Frame geopackage database.
-    full_db_name: Path to the output .duckdb file for the full deduped bursts.
     """
     if full_db_path is None:
         today = datetime.now().strftime("%Y-%m-%d")


### PR DESCRIPTION
`opera-db create` threw this error:

```python-traceback
  File "/Users/staniewi/repos/burst_db/src/burst_db/build_frame_db.py", line 713, in create
    add_gpkg_spatial_ref_sys(outfile)
  File "/Users/staniewi/repos/burst_db/src/burst_db/build_frame_db.py", line 388, in add_gpkg_spatial_ref_sys
    con.execute(sql, UTM_32760_DEF)
sqlite3.ProgrammingError: Incorrect number of bindings supplied. The current statement uses 1, and there are 605 supplied.
```

Looks like #41 was missing a comma, since the interpolation value needs to be a tuple instead of a string. 