### PR TITLE
Enable opera-db create for Sentinel-1 EW mode

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,8 @@ dependencies:
 - shapely
 - tqdm
 - utm
+- libspatialite
+- gdal
 - pip:
   - unzip-http
+  - rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ shapely
 tqdm
 unzip-http
 utm
+rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ geopandas
 numpy
 opera-utils
 pandas
+rich
 shapely
 tqdm
 unzip-http
 utm
-rich

--- a/src/burst_db/_esa_burst_db.py
+++ b/src/burst_db/_esa_burst_db.py
@@ -10,10 +10,15 @@ from pathlib import Path
 ESA_DB_URL = "https://sar-mpc.eu/files/S1_burstid_20220530.zip"
 
 
-def get_esa_burst_db(output_path="burst_map_IW_000001_375887.sqlite3"):
+def get_esa_burst_db(
+    output_path="burst_map_IW_000001_375887.sqlite3", sensor_mode="IW"
+):
     """Download the ESA burst database."""
     print(f"Downloading ESA burst database from {ESA_DB_URL} to {output_path}.")
-    db_filename = "S1_burstid_20220530/IW/sqlite/burst_map_IW_000001_375887.sqlite3"
+    if sensor_mode == "IW":
+        db_filename = "S1_burstid_20220530/IW/sqlite/burst_map_IW_000001_375887.sqlite3"
+    else:
+        db_filename = "S1_burstid_20220530/EW/sqlite/burst_map_EW_000001_341235.sqlite3"
     cur_dir = Path.cwd()
     output_path = Path(output_path).absolute()
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/burst_db/build_frame_db.py
+++ b/src/burst_db/build_frame_db.py
@@ -60,15 +60,16 @@ def _setup_spatialite_con(con: sqlite3.Connection):
     con.execute("SELECT EnableGpkgAmphibiousMode();")
 
 
-def make_burst_triplets(df_burst: pd.DataFrame) -> pd.DataFrame:
-    """Make a burst triplets dataframe, aggregating IW1,2,3 from the burst dataframe."""
+def make_burst_swath_aggregate(df_burst: pd.DataFrame) -> pd.DataFrame:
+    """Make a burst swath aggreate dataframe,
+    aggregating IW1,2,3 or EW1,2,3,4,5 from the burst dataframe."""
 
     def join_track_numbers(orbits: list) -> str:
         orbits = list(set(orbits))
         orbits_str = list(map(str, orbits))
         return ",".join(orbits_str)
 
-    df_burst_triplet_temp = df_burst.dissolve(
+    df_burst_swaths_temp = df_burst.dissolve(
         by="burst_id",
         aggfunc={
             "OGC_FID": ["min", "max"],
@@ -77,8 +78,8 @@ def make_burst_triplets(df_burst: pd.DataFrame) -> pd.DataFrame:
         },
         as_index=False,
     )
-    df_burst_triplet = df_burst_triplet_temp.reset_index(drop=True)
-    df_burst_triplet.columns = [
+    df_burst_swaths = df_burst_swaths_temp.reset_index(drop=True)
+    df_burst_swaths.columns = [
         "burst_id",
         "geom",
         "OGC_FID_min",
@@ -86,7 +87,7 @@ def make_burst_triplets(df_burst: pd.DataFrame) -> pd.DataFrame:
         "relative_orbit_numbers",
         "look_direction",
     ]
-    return df_burst_triplet
+    return df_burst_swaths
 
 
 def get_intersect_indicator(gdf: gpd.GeoDataFrame, test_geom: GeometryType.POLYGON):
@@ -575,11 +576,21 @@ def create_metadata_table(db_path, metadata):
 
 @click.command(context_settings={"show_default": True})
 @click.option(
+    "--sensor-mode",
+    type=click.Choice(["IW", "EW"]),
+    default="IW",
+    show_default=True,
+    help="Sentinel-1 acquisition sensor mode.",
+)
+@click.option(
     "--esa-db-path",
-    default="burst_map_IW_000001_375887.sqlite3",
+    default=None,
     help=(
         "Path to the ESA sqlite burst database to convert, downloaded from"
-        f" {ESA_DB_URL}. Will be downloaded if not exists."
+        f" {ESA_DB_URL}. Will be downloaded if not exists. If None, default"
+        " is set based on the --sensor-mode value. "
+        " IW -> burst_map_IW_000001_375887.sqlite3"
+        " EW -> burst_map_EW_000001_341235.sqlite3"
     ),
 )
 @click.option(
@@ -619,6 +630,7 @@ def create_metadata_table(db_path, metadata):
     help="A buffer (in degrees) to indicate that a frame is near land.",
 )
 def create(
+    sensor_mode,
     esa_db_path,
     snap,
     margin,
@@ -632,10 +644,18 @@ def create(
     """Generate the OPERA frame database for Sentinel-1 data."""
     t0 = time.time()
 
+    # if the desired output esa_db_path is not provided, set
+    # based on the selected sensor mode
+    if esa_db_path is None:
+        esa_db_path = {
+            "IW": "burst_map_IW_000001_375887.sqlite3",
+            "EW": "burst_map_EW_000001_341235.sqlite3",
+        }[sensor_mode]
+
     # Read ESA's Burst Data
     if not Path(esa_db_path).exists():
         logger.info(f"Downloading {ESA_DB_URL} to {esa_db_path}...")
-        get_esa_burst_db(esa_db_path)
+        get_esa_burst_db(esa_db_path, sensor_mode.upper())
 
     logger.info("Loading burst data...")
     sql = "SELECT * FROM burst_id_map"
@@ -663,15 +683,18 @@ def create(
     with sqlite3.connect(outfile) as con:
         con.execute("ALTER TABLE burst_id_map RENAME COLUMN fid TO OGC_FID;")
 
-    logger.info("Aggregating burst triplets (grouping IW1,2,3 geometries together)")
-    df_burst_triplet = make_burst_triplets(df_burst)
+    logger.info(
+        "Aggregating burst swaths (grouping IW1,2,3 or "
+        "EW1,2,3,4,5 geometries together)"
+    )
+    df_burst_swaths = make_burst_swath_aggregate(df_burst)
 
     # Get the land polygon to intersect
-    logger.info("Indicating which burst triplets are near land...")
+    logger.info("Indicating which burst swath aggregates are near land...")
     df_land = get_land_df(land_buffer_deg)
     land_geom = df_land.geometry
 
-    is_in_land = get_intersect_indicator(df_burst_triplet, land_geom)
+    is_in_land = get_intersect_indicator(df_burst_swaths, land_geom)
 
     # Create frames and JOIN tables
     # Make the JOIN table first
@@ -682,6 +705,7 @@ def create(
         min_frame=min_frame,
         max_frame=max_frame,
         optimize_land=optimize_land,
+        n_subswaths={"IW":3, "EW":5}[sensor_mode],
     )
     make_frame_to_burst_table(outfile, df_frame_to_burst_id)
 

--- a/src/burst_db/build_frame_db.py
+++ b/src/burst_db/build_frame_db.py
@@ -61,8 +61,10 @@ def _setup_spatialite_con(con: sqlite3.Connection):
 
 
 def make_burst_swath_aggregate(df_burst: pd.DataFrame) -> pd.DataFrame:
-    """Make a burst swath aggreate dataframe,
-    aggregating IW1,2,3 or EW1,2,3,4,5 from the burst dataframe."""
+    """Make a burst swath aggreate dataframe,.
+
+    aggregating IW1,2,3 or EW1,2,3,4,5 from the burst dataframe.
+    """
 
     def join_track_numbers(orbits: list) -> str:
         orbits = list(set(orbits))
@@ -705,7 +707,7 @@ def create(
         min_frame=min_frame,
         max_frame=max_frame,
         optimize_land=optimize_land,
-        n_subswaths={"IW":3, "EW":5}[sensor_mode],
+        n_subswaths={"IW": 3, "EW": 5}[sensor_mode],
     )
     make_frame_to_burst_table(outfile, df_frame_to_burst_id)
 

--- a/src/burst_db/frames.py
+++ b/src/burst_db/frames.py
@@ -31,6 +31,7 @@ def create_frame_to_burst_mapping(
     min_frame: int,
     max_frame: int,
     optimize_land: bool = False,
+    n_subswaths: int = 3,  # 3 for IW, 5 for EW
 ) -> pd.DataFrame:
     """Create the JOIN table between frames_number and burst_id."""
     if not optimize_land:
@@ -50,7 +51,10 @@ def create_frame_to_burst_mapping(
         cumulative_slice_idxs, start=1
     ):
         for burst_id in range(start_idx + 1, end_idx + 1):
-            for ogc_fid in range(1 + 3 * (burst_id - 1), 4 + 3 * (burst_id - 1)):
+            for ogc_fid in range(
+                1 + n_subswaths * (burst_id - 1),
+                1 + n_subswaths * burst_id,  # exclusive end
+            ):
                 frame_ogc_fid_tuples.append((frame_id, ogc_fid, is_land))
 
     df_frame_to_burst_id = pd.DataFrame(


### PR DESCRIPTION
### Expanding the logic to enable the creation of a burst-db for Sentinel-1's Extra Wide (EW) Mode.

### Rationale

These changes are needed to create the bursts database for the Sentinel-1 EW mode. It is an important resource in polar regions, where processing EW SLC data can enable new scientific insights. The changes extend the software's capabilities and should not impact any existing behaviour.

### Changes

- Adding missing dependencies to the environment file for conda build 
- Adding a `--sensor-mode` option to the `opera-db create` CLI. This defaults to IW, so the logic for building the IW database should be unchanged. Specifying `--sensor-mode EW` will download and build the database from ESA's EW burst map (`burst_map_EW_000001_341235.sqlite3`), rather than the IW burst map (`burst_map_IW_000001_375887.sqlite3`).
- Minor logic changes to account for the different subswath count in EW (n=5) and IW (n=3) modes. 

```bash
opera-db create --help
Usage: opera-db create [OPTIONS]

  Generate the OPERA frame database for Sentinel-1 data.

Options:
  --sensor-mode [IW|EW]    Sentinel-1 acquisition sensor mode.  [default: IW]
  --esa-db-path TEXT       Path to the ESA sqlite burst database to convert,
                           downloaded from https://sar-
                           mpc.eu/files/S1_burstid_20220530.zip. Will be
                           downloaded if not exists. If None, default is set
                           based on the --sensor-mode value.  IW ->
                           burst_map_IW_000001_375887.sqlite3 EW ->
                           burst_map_EW_000001_341235.sqlite3
  --snap FLOAT             Snap the bounding box to the nearest multiple of
                           this value.  [default: 30.0]
  --margin FLOAT           Add this margin surrounding the bounding box of
                           bursts.  [default: 5000.0]
  --optimize-land          Create frames which attempt to minimize the number
                           of majority-water frames.
  --target-frame INTEGER   Target number of bursts per frame.  [default: 9]
  --min-frame INTEGER      (If using `--optimize-land`): Minimum number of
                           bursts per frame.  [default: 5]
  --max-frame INTEGER      (If using `--optimize-land`): Maximum number of
                           bursts per frame.  [default: 10]
  --outfile TEXT           Output file name  [default:
                           opera-s1-disp-0.0.post1.gpkg]
  --land-buffer-deg FLOAT  A buffer (in degrees) to indicate that a frame is
                           near land.  [default: 0.3]
  --help                   Show this message and exit.
```